### PR TITLE
Fix newline spacing in Classes

### DIFF
--- a/Legobot/Limit.py
+++ b/Legobot/Limit.py
@@ -2,17 +2,15 @@ import ctypes
 KIPR=ctypes.CDLL("/usr/lib/libkipr.so")
 
 class Limit:
+    
     def __init__(self, port):
         self.port = port
-    
-    
+
     def get_value(self):
         return KIPR.digital(self.port)
-    
-    
+
     def is_pressed(self):
         return self.get_value() == 1
-    
-    
+
     def is_unpressed(self):
         return self.get_value() == 0

--- a/Legobot/Motor.py
+++ b/Legobot/Motor.py
@@ -4,6 +4,7 @@ from decorators import *
 import constants as c
 
 class Motor:
+    
     all_motors = []
     
     # Consider these "private variables"
@@ -15,12 +16,10 @@ class Motor:
         self.full_power = base_power
         self.direction = direction
         Motor.all_motors.append(self)
-        
 
     # This is relative to a forward direction. Current power 
     def get_power(self):
         return self.current_power
-
 
     def set_power(self, power):
         if power > 1450:
@@ -30,22 +29,18 @@ class Motor:
         KIPR.mav(self.port, int(self.direction * power))
         self.current_power = int(self.direction * power)
 
-    
     def set_reference_powers(self, new_reference_power):
         self.base_power = new_reference_power
         self.full_power = new_reference_power
         self.half_power = new_reference_power / 2
 
-
     # This is relative to a forward direction.
     def get_tics(self):
         return KIPR.gmpc(self.port) * self.direction
 
-
     def clear_tics(self):
         KIPR.cmpc(self.port)
-    
-    
+
     def accelerate_to(self, desired_power):
         if desired_power < 1 and desired_power >= 0:
             desired_power = 1
@@ -63,11 +58,9 @@ class Motor:
                 KIPR.msleep(1)
         self.set_power(desired_power)  # Ensures actual desired value is reached
 
-
     # TODO add decelleration
     def stop(self):
         self.set_power(0)
-
 
     @print_function_name_with_arrows
     def forwards_until(self, boolean_function, *, time=c.SAFETY_TIME, should_stop=True):
@@ -78,8 +71,7 @@ class Motor:
             KIPR.msleep(1)
         if should_stop:
             self.stop()
-    
-    
+
     @print_function_name_with_arrows
     def backwards_until(self, boolean_function, *, time=c.SAFETY_TIME, should_stop=True):
         # Left motor goes forwards until right tophat senses black
@@ -89,8 +81,7 @@ class Motor:
             KIPR.msleep(1)
         if should_stop:
             self.stop()
-            
-            
+
     # This function treats the motor like a servo.
     @print_function_name_with_arrows
     def move(self, desired_tic_location, desired_speed):
@@ -116,7 +107,7 @@ class Motor:
             self.set_power(speed)
             KIPR.msleep(1)
         self.stop()
-    
+
     #------------------------------- Static Two-Motor Commands -------------------------------
     # These commands are really the building blocks of the whole code. They're practical; they're
     # built to be used on a daily basis. If you're going to copy something of our code, I would suggest that it be this
@@ -143,7 +134,6 @@ class Motor:
                 KIPR.msleep(1)
         left_motor.set_power(left_motor_power)
         right_motor.set_power(right_motor_power)  # Ensures actual desired value is reached.
-
 
     def deactivate_motors():
         left_motor = Motor.all_motors[0]

--- a/Legobot/Servo.py
+++ b/Legobot/Servo.py
@@ -3,10 +3,11 @@ KIPR=ctypes.CDLL("/usr/lib/libkipr.so")
 from decorators import *
 
 class Servo:
+
     universal_max_pos = 1950
     universal_min_pos = 50
     all_servos = []
-    
+
     def __init__(self, port, starting_pos=1024, max_pos=universal_max_pos, min_pos=universal_min_pos):
         self.port = port
         self.max_pos = max_pos
@@ -17,11 +18,9 @@ class Servo:
         else:
             self.direction = -1
         Servo.all_servos.append(port)
-            
 
     def get_pos(self):
         return get_servo_position(self.port)
-
 
     def set_pos(self, pos):
         if direction == 1:
@@ -35,7 +34,6 @@ class Servo:
             elif pos > self.min_pos:
                 pos = self.min_pos
         KIPR.set_servo_position(self.port, pos)
-
 
     def move(self, desired_pos, tics=3, ms=1):
         # Moves a servo to a given position from its current position. The servo and desired position must be specified.
@@ -64,25 +62,21 @@ class Servo:
         print("Desired position reached. Curent position is %d" % get_servo_position(self.port))
         print("Completed servo_slow\n")
 
-
     @print_function_name
     def move_up(self, tics):
         desired_pos = get_servo_position(self.port) + tics * self.direction
         self.move_servo(desired_pos)
 
-
     @print_function_name
     def move_down(self):
         desired_pos = get_servo_position(self.port) - tics * self.direction
         self.move_servo(desired_pos)
-        
-        
+
     @print_function_name
     def move_right(self):
         desired_pos = get_servo_position(self.port) + tics * self.direction
         self.move_servo(desired_pos)
-        
-    
+
     @print_function_name
     def move_left(self):
         desired_pos = get_servo_position(self.port) - tics * self.direction

--- a/Legobot/Tophat.py
+++ b/Legobot/Tophat.py
@@ -6,6 +6,7 @@ import objects as o
 import Motor as M
 
 class Tophat:
+    
     refresh_rate = 30
     all_tophats = []
     
@@ -22,34 +23,27 @@ class Tophat:
         self.tophat_type = tophat_type
         Tophat.all_tophats.append(self)
 
-            
     def get_value(self):
         return KIPR.analog(self.port)
 
-
     def get_value_midpoint(self):
         return KIPR.self.value_midpoint
-        
 
     def senses_black(self):
         return self.get_value() < self.value_midpoint
-    
-    
+
     def senses_white(self):
         return self.get_value() > self.value_midpoint
-    
-    
+
     def compare_and_replace_extremes(self):
         if self.get_value() > self.black_value:
             self.black_value = self.get_value()
         elif self.get_value() < self.white_value:
             self.white_value = self.get_value()
-    
-    
+
     def determine_midpoint_from_extremes(self, bias):
         self.set_value_midpoint((self.black_value + self.white_value) / 2 + bias)
 
-        
     def lfollow(self, time, mode=c.STANDARD, should_stop=True, bias=0):
         target = 100.0 * (self.value_midpoint - self.white_value) / (self.black_value - self.white_value) + bias
         last_error = 0
@@ -84,7 +78,6 @@ class Tophat:
         if should_stop:
             M.Motor.deactivate_motors()
 
-    
     def lfollow_until(self, boolean_function, mode=c.STANDARD, should_stop=True, bias=0, *, time=c.SAFETY_TIME):
         target = 100.0 * (self.value_midpoint - self.white_value) / (self.black_value - self.white_value) + bias
         last_error = 0
@@ -119,7 +112,6 @@ class Tophat:
         if should_stop:
             M.Motor.deactivate_motors()
 
-
     def lfollow_choppy(self, time, should_stop=True):
         left_motor = M.Motor.all_motors[0]
         right_motor = M.Motor.all_motors[1]
@@ -134,4 +126,3 @@ class Tophat:
             KIPR.msleep(30)
         if should_stop:
             M.Motor.deactivate_motors()
-        

--- a/Roomba/Cliff.py
+++ b/Roomba/Cliff.py
@@ -4,7 +4,7 @@ import constants as c
 import movement as m
 
 class Cliff:
-    
+
     all_cliffs = []
     
     def __init__(self, get_value_function, side):
@@ -14,27 +14,22 @@ class Cliff:
         self.value_midpoint = -1
         self.side = side
         Cliff.all_cliffs.append(self)    
-    
-        
+
     def get_value(self):
         # Gets value that the cliff currently reads.
         return self.get_value_function()
-    
-    
+
     def get_value_midpoint(self):
         # Gets the value midpoint of the cliff.
         return self.value_midpoint
-    
-    
+
     def senses_black(self):
         # Returns whether or not the cliff senses black.
         return self.get_value < self.value_midpoint
-    
-    
+
     def senses_white(self):
         # Returns whether or not the cliff senses white.
         return self.get_value < self.value_midpoint
-    
 
 # ------------------------- Lfollow Commands ----------------------------------
 # The roomba hugs onto a line with a cliff as it moves forward.
@@ -71,7 +66,6 @@ class Cliff:
             msleep(1)
         if should_stop:
             m.deactivate_motors()
-
 
     @print_function_name
     def lfollow_until(self, boolean_function, mode=c.STANDARD, bias=10, *, should_stop=True, time=c.SAFETY_TIME):
@@ -121,9 +115,9 @@ class Cliff:
             msleep(refresh_rate)
         if should_stop:
             m.deactivate_motors()
-    
+
     #------------------- Basic Movement Until Black/White ------------------------------
-    
+
     @print_function_name
     def forward_until_black(self, should_stop=True, *, time=c.SAFETY_TIME):
         m.base_forward()
@@ -132,8 +126,7 @@ class Cliff:
             msleep(1)
         if should_stop:
             m.deactivate_motors()
-    
-    
+
     @print_function_name
     def forward_until_white(self, should_stop=True, *, time=c.SAFETY_TIME):
         m.base_forward()
@@ -142,8 +135,7 @@ class Cliff:
             msleep(1)
         if should_stop:
             m.deactivate_motors()
-    
-    
+
     @print_function_name
     def backwards_until_black(self, should_stop=True, *, time=c.SAFETY_TIME):
         m.base_backwards()
@@ -152,8 +144,7 @@ class Cliff:
             msleep(1)
         if should_stop:
             m.deactivate_motors()
-    
-    
+
     @print_function_name
     def backwards_until_white(self, should_stop=True, *, time=c.SAFETY_TIME):
         m.base_backwards()
@@ -162,31 +153,27 @@ class Cliff:
             msleep(1)
         if should_stop:
             m.deactivate_motors()
-    
+
     #------------------- Basic Movement Through/Until Lines ------------------------------
-    
+
     @print_function_name
     def forward_through_line(self, should_stop=True, *, time=c.SAFETY_TIME):
         self.forward_until_black(should_stop=False)
         self.forward_until_white(should_stop, time=time)
-        
-    
+
     @print_function_name
     def forward_until_line(self, should_stop=True, *, time=c.SAFETY_TIME):
         self.forward_until_white(should_stop=False)
         self.forward_until_black(should_stop, time=time)
-
 
     @print_function_name
     def backwards_through_line(self, should_stop=True, *, time=c.SAFETY_TIME):
         self.backwards_until_black(should_stop=False)
         self.backwards_until_white(should_stop, time=time)
 
-
     @print_function_name
     def backwards_until_line(self, should_stop=True, *, time=c.SAFETY_TIME):
         self.backwards_until_white(should_stop=False)
         self.backwards_until_black(should_stop, time=time)
 
-    
         

--- a/Roomba/Depth.py
+++ b/Roomba/Depth.py
@@ -4,19 +4,16 @@ import constants as c
 import movement as m
 
 class Depth:
-    
+
     def __init__(self, port, value_midpoint):
         self.value_midpoint = value_midpoint
         self.port = port
-    
-    
+
     def get_value(self):
         return analog(self.port)
 
-
     def senses_object(self):
         return self.get_value() > self.value_midpoint
-    
-    
+
     def senses_nothing(self):
-        return self.get_value() < self.value_midpoint        
+        return self.get_value() < self.value_midpoint

--- a/Roomba/Limit.py
+++ b/Roomba/Limit.py
@@ -4,17 +4,15 @@ import constants as c
 import movement as m
 
 class Limit:
+
     def __init__(self, port):
         self.port = port
-    
-    
+
     def get_value(self):
         return digital(self.port)
-    
-    
+
     def is_pressed(self):
         return self.get_value() == 1
-    
-    
+
     def is_unpressed(self):
         return self.get_value() == 0

--- a/Roomba/Servo.py
+++ b/Roomba/Servo.py
@@ -2,10 +2,11 @@ from wombat import *
 from decorators import *
 
 class Servo:
+
     universal_max_pos = 1950
     universal_min_pos = 50
     all_servos = []
-    
+
     def __init__(self, port, starting_pos=1024, max_pos=universal_max_pos, min_pos=universal_min_pos):
         self.port = port
         self.max_pos = max_pos
@@ -16,11 +17,9 @@ class Servo:
         else:
             self.direction = -1
         Servo.all_servos.append(port)
-            
 
     def get_pos(self):
         return get_servo_position(self.port)
-
 
     def set_pos(self, pos):
         if direction == 1:
@@ -34,7 +33,6 @@ class Servo:
             elif pos > self.min_pos:
                 pos = self.min_pos
         set_servo_position(self.port, pos)
-
 
     def move(self, desired_pos, tics=3, ms=1):
         # Moves a servo to a given position from its current position. The servo and desired position must be specified.
@@ -63,25 +61,21 @@ class Servo:
         print "Desired position reached. Curent position is %d" % get_servo_position(self.port)
         print "Completed servo_slow\n"
 
-
     @print_function_name
     def move_up(self, tics):
         desired_pos = get_servo_position(self.port) + tics * self.direction
         self.move_servo(desired_pos)
 
-
     @print_function_name
     def move_down(self):
         desired_pos = get_servo_position(self.port) - tics * self.direction
         self.move_servo(desired_pos)
-        
-        
+
     @print_function_name
     def move_right(self):
         desired_pos = get_servo_position(self.port) + tics * self.direction
         self.move_servo(desired_pos)
-        
-    
+
     @print_function_name
     def move_left(self):
         desired_pos = get_servo_position(self.port) - tics * self.direction


### PR DESCRIPTION
According to PEP-8, class methods should only have one newline between them. Also, there should be a newline after the `Class` line.